### PR TITLE
Adds capability to programmatically hide selector on iOS

### DIFF
--- a/src/ios/SelectorCordovaPlugin.h
+++ b/src/ios/SelectorCordovaPlugin.h
@@ -3,6 +3,7 @@
 
 @interface SelectorCordovaPlugin : CDVPlugin
 
-- (void)showSelector:(CDVInvokedUrlCommand*)command;
+- (void)showSelector:(CDVInvokedUrlCommand *)command;
+- (void)hideSelector:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/SelectorCordovaPlugin.m
+++ b/src/ios/SelectorCordovaPlugin.m
@@ -12,6 +12,10 @@
 // UIInterfaceOrientationMask.
 #define OrientationMaskSupportsOrientation(mask, orientation)   ((mask & (1 << orientation)) != 0)
 
+typedef NS_ENUM(NSInteger, SelectorResultType) {
+  SelectorResultTypeCanceled = 0,
+  SelectorResultTypeDone = 1
+};
 
 @interface SelectorCordovaPlugin () <UIActionSheetDelegate, UIPopoverControllerDelegate, UIPickerViewDelegate, UIPickerViewDataSource>
 
@@ -126,33 +130,36 @@
   return toolbar;
 }
 
-- (void)sendResultsFromPickerView:(UIPickerView *)pickerView withButtonIndex:(NSInteger)buttonIndex {
-  NSMutableArray *arr = [[NSMutableArray alloc] init];
-  NSArray *sortedKeys = [[_itemsSelectedIndexes allKeys] sortedArrayUsingSelector: @selector(compare:)];
+- (void)sendResultsFromPickerView:(UIPickerView *)pickerView resultType:(SelectorResultType)resultType {
+  CDVPluginResult *pluginResult;
 
-  for (NSString *key in sortedKeys){
-    NSString *theKey = key;
-    NSInteger indexInDict = [theKey integerValue];
-    NSInteger index = [[_itemsSelectedIndexes objectForKey:key] integerValue];
-    NSString *indexAsString = [@(index) stringValue];
+  if (resultType == SelectorResultTypeDone) {
+    NSMutableArray *arr = [[NSMutableArray alloc] init];
+    NSArray *sortedKeys = [[_itemsSelectedIndexes allKeys] sortedArrayUsingSelector: @selector(compare:)];
 
-    NSString* valueFound = _items[indexInDict][index];
-    NSDictionary *tmpDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
-                                   indexAsString, @"index",
-                                   valueFound, [_options objectForKey:@"displayKey"], nil];
+    for (NSString *key in sortedKeys) {
+      NSString *theKey = key;
+      NSInteger indexInDict = [theKey integerValue];
+      NSInteger index = [[_itemsSelectedIndexes objectForKey:key] integerValue];
+      NSString *indexAsString = [@(index) stringValue];
 
-    [arr addObject:tmpDictionary];
-  }
+      NSString *valueFound = _items[indexInDict][index];
+      NSDictionary *tmpDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
+                                     indexAsString, @"index",
+                                     valueFound, [_options objectForKey:@"displayKey"], nil];
 
-  CDVPluginResult* pluginResult;
+      [arr addObject:tmpDictionary];
+    }
 
-  if (buttonIndex == 0) {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
-  } else {
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:arr];
   }
 
-  [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];;
+  if (resultType == SelectorResultTypeCanceled) {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
+  _callbackId = nil;
 }
 
 #pragma mark - Show picker
@@ -209,39 +216,44 @@
 
   if (OrientationMaskSupportsOrientation(supportedInterfaceOrientations, DEVICE_ORIENTATION)) {
     if (IS_IPAD) {
-      [self dismissPopoverController:_popoverController withButtonIndex:0 animated:YES];
+      [self dismissPopoverController:_popoverController animated:YES];
     } else {
-      [self dismissModalView:_modalView withButtonIndex:0 animated:YES];
+      [self dismissModalView:_modalView animated:YES];
     }
+
+    [self sendResultsFromPickerView:_pickerView resultType:SelectorResultTypeCanceled];
   }
 }
 
 - (IBAction)didDismissWithDoneButton:(id)sender {
   if (IS_IPAD) {
-    [self dismissPopoverController:_popoverController withButtonIndex:1 animated:YES];
+    [self dismissPopoverController:_popoverController animated:YES];
   } else {
-    [self dismissModalView:_modalView withButtonIndex:1 animated:YES];
+    [self dismissModalView:_modalView animated:YES];
   }
+
+  [self sendResultsFromPickerView:_pickerView resultType:SelectorResultTypeDone];
 }
 
 - (IBAction)didDismissWithCancelButton:(id)sender {
   if (IS_IPAD) {
-    [self dismissPopoverController:_popoverController withButtonIndex:0 animated:YES];
+    [self dismissPopoverController:_popoverController animated:YES];
   } else {
-    [self dismissModalView:_modalView withButtonIndex:0 animated:YES];
+    [self dismissModalView:_modalView animated:YES];
   }
+
+  [self sendResultsFromPickerView:_pickerView resultType:SelectorResultTypeCanceled];
 }
 
 - (void)popoverControllerDidDismissPopover:(UIPopoverController *)popoverController {
-  [self sendResultsFromPickerView:_pickerView withButtonIndex:0];
+  [self sendResultsFromPickerView:_pickerView resultType:SelectorResultTypeCanceled];
 }
 
-- (void)dismissPopoverController:(UIPopoverController *)popoverController withButtonIndex:(NSInteger)buttonIndex animated:(Boolean)animated {
+- (void)dismissPopoverController:(UIPopoverController *)popoverController animated:(Boolean)animated {
   [popoverController dismissPopoverAnimated:animated];
-  [self sendResultsFromPickerView:_pickerView withButtonIndex:buttonIndex];
 }
 
-- (void)dismissModalView:(UIView *)modalView withButtonIndex:(NSInteger)buttonIndex animated:(Boolean)animated {
+- (void)dismissModalView:(UIView *)modalView animated:(Boolean)animated {
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillChangeStatusBarOrientationNotification object:nil];
 
   // Hide the view animated
@@ -256,8 +268,6 @@
                    completion:^(BOOL finished) {
                      [_modalView removeFromSuperview];
                    }];
-
-  [self sendResultsFromPickerView:_pickerView withButtonIndex:buttonIndex];
 }
 
 #pragma mark - UIPickerViewDelegate

--- a/src/ios/SelectorCordovaPlugin.m
+++ b/src/ios/SelectorCordovaPlugin.m
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSInteger, SelectorResultType) {
 
 @implementation SelectorCordovaPlugin
 
-- (void)showSelector:(CDVInvokedUrlCommand*)command {
+- (void)showSelector:(CDVInvokedUrlCommand *)command {
   _callbackId = command.callbackId;
 
   // NOTE: All default options are assumed to be set in JS code
@@ -63,6 +63,16 @@ typedef NS_ENUM(NSInteger, SelectorResultType) {
   } else {
     return [self presentModalViewForView:view];
   }
+}
+
+- (void)hideSelector:(CDVInvokedUrlCommand *)command {
+  if (_callbackId) {
+    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR] callbackId:_callbackId];
+    _callbackId = nil;
+  }
+
+  _callbackId = command.callbackId;
+  [self didDismissWithCancelButton:self];
 }
 
 - (UIView *)createPickerView {

--- a/www/selectorplugin.js
+++ b/www/selectorplugin.js
@@ -1,59 +1,61 @@
-var exec = require('cordova/exec');
 
 var PLUGIN_NAME = 'SelectorCordovaPlugin';
+var SelectorCordovaPlugin = function() {};
 
-var SelectorCordovaPlugin = {
-  showSelector: function(options, cb, error_callback) {
-      options || (options = {});
-      var scope = options.scope || null;
+SelectorCordovaPlugin.prototype.showSelector = function(options, success_callback, error_callback) {
+  options || (options = {});
+  var scope = options.scope || null;
 
-      function Create2DArray(rows) {
-          var arr = [];
+  function Create2DArray(rows) {
+      var arr = [];
 
-          for (var i=0;i<rows;i++) {
-              arr[i] = [];
-          }
-
-          return arr;
+      for (var i=0;i<rows;i++) {
+          arr[i] = [];
       }
 
-      var displayList = Create2DArray(options.items.length);
-
-      var config = {
-          title: options.title || ' ',
-          displayKey: options.displayKey || 'description',
-          items: options.items || {},
-          displayItems: displayList,
-          defaultItems: options.defaultItems || {},
-          theme: options.theme || 'light',
-          wrapWheelText: options.wrapWheelText || false,
-          positiveButtonText: options.positiveButtonText || 'Done',
-          negativeButtonText: options.negativeButtonText || 'Cancel',
-          fontSize: options.fontSize || 16
-      };
-
-      for(i in config.items) {
-          for (k in config.items[i]) {
-              for (n in config.items[i][k]) {
-                  displayList[i][n] = config.items[i][k][n][config.displayKey];
-              }
-          }
-      }
-
-      var _callback = function() {
-          if(typeof cb == 'function') {
-              cb.apply(scope, arguments);
-          }
-      };
-
-      var _error_callback = function() {
-          if(typeof error_callback == 'function') { 
-              error_callback.apply(scope, arguments);
-      }
-    };
-
-    exec(_callback, _error_callback, PLUGIN_NAME, 'showSelector', [config]);
+      return arr;
   }
+
+  var displayList = Create2DArray(options.items.length);
+
+  var config = {
+      title: options.title || ' ',
+      displayKey: options.displayKey || 'description',
+      items: options.items || {},
+      displayItems: displayList,
+      defaultItems: options.defaultItems || {},
+      theme: options.theme || 'light',
+      wrapWheelText: options.wrapWheelText || false,
+      positiveButtonText: options.positiveButtonText || 'Done',
+      negativeButtonText: options.negativeButtonText || 'Cancel',
+      fontSize: options.fontSize || 16
+  };
+
+  for(i in config.items) {
+      for (k in config.items[i]) {
+          for (n in config.items[i][k]) {
+              displayList[i][n] = config.items[i][k][n][config.displayKey];
+          }
+      }
+  }
+
+  var _success_callback = function() {
+      if(typeof success_callback == 'function') {
+          success_callback.apply(scope, arguments);
+      }
+  };
+
+  var _error_callback = function() {
+      if(typeof error_callback == 'function') {
+          error_callback.apply(scope, arguments);
+      }
+  }
+
+  return cordova.exec(_success_callback, _error_callback, PLUGIN_NAME, 'showSelector', [config]);
 };
 
-module.exports = SelectorCordovaPlugin;
+SelectorCordovaPlugin.prototype.hideSelector = function(success_callback, error_callback) {
+  return cordova.exec(success_callback, error_callback, PLUGIN_NAME, 'hideSelector', []);
+};
+
+module.exports = new SelectorCordovaPlugin();


### PR DESCRIPTION
Hi,
This wasn't requested, but I needed this feature on my project and thought it might be useful to have it here as well.
Haven't updated documentation, and neither the plugin version. Should those be updated when platform specific changes are made?
Also, I was having issues when adding second plugin function and eventually changed selectorplugin.js structure, hope it's OK.

- [commit 1] Moves plugin callback calls out from dismiss functions; replaces hardcoded button indexes with enum
- [commit 2] Adds hide selector functionality

