### PR TITLE
Fix documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Using config:
 var config = {
     title: "Select a quantity",
     items:[
-        data.numbers
+        [data.numbers]
     ],
     positiveButtonText: "Done",
     negativeButtonText: "Cancel"


### PR DESCRIPTION
Hello,

I found missed brackets in example config. It's been fixed