### PR TITLE
Exclude `examples` folder from NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+/examples


### PR DESCRIPTION
The new `.npmignore` file prevents the `examples` folder being downloaded via NPM, which can otherwise cause compile errors when the host project uses incompatible `tsconfig.json` settings, e.g. `"noImplicitAny":true`.